### PR TITLE
[French] Orthotypographic corrections

### DIFF
--- a/content/index.fr.md
+++ b/content/index.fr.md
@@ -4,7 +4,7 @@ title: "Impliquer les utilisateurs dans l’évaluation de l’accessibilité We
 permalink: /test-evaluate/involving-users/fr
 ref: /test-evaluate/involving-users/
 lang: fr
-last_updated: 2021-06-02
+last_updated: 2021-07-12
 translators:
 - name: "Rémi Bétin"
 - name: "Sofia Ahmed"
@@ -53,10 +53,10 @@ Cette page introduit des considérations pour les tests d’utilisabilité et au
 {% include excol.html type="middle" %}
 
 {% include video-player.html
-yt-id="lIA2zTXq_ts"
-path="/content-images/wai-InvolveUsersEval/"
-captions="involving-users-cc.vtt|en"
-subtitles="involving-users-fr.vtt|fr|default"
+    yt-id="lIA2zTXq_ts"
+    path="/content-images/wai-InvolveUsersEval/"
+    captions="involving-users-cc.vtt|en"
+    subtitles="involving-users-fr.vtt|fr|default"
 %}
 
 _Cette vidéo est aussi disponible sur un serveur du W3C : [Vidéo : Impliquer les utilisateurs dans l’accessibilité Web – Vue d’ensemble (format du fichier : MP4, taille du fichier : 38 Mo)](http://media.w3.org/wai/evaluation-intros/involving-users.mp4)._
@@ -76,11 +76,11 @@ Transcription textuelle avec description des visuels
   </thead>
 <tbody>
   <tr>
-    <td>Impliquer les utilisateurs dans l’accessibilité Web. </td>
+    <td>Impliquer les utilisateurs dans l’accessibilité Web.</td>
     <td>Impliquer les utilisateurs dans l’accessibilité Web.</td>
   </tr>
   <tr>
-    <td>L’accessibilité Web consiste à rendre vos sites et vos applications Web utilisables par des personnes en situation de handicap. Nous parlons de vos consommateurs, de vos clients, de vos employés, de vos étudiants, etc. </td>
+    <td>L’accessibilité Web consiste à rendre vos sites et vos applications Web utilisables par les personnes en situation de handicap. Il s’agit de vos consommateurs, de vos clients, de vos employés, de vos étudiants, etc. </td>
     <td>L’accessibilité. Une personne se trouve face à un ordinateur. À côté de l’ordinateur apparaissent les mots : consommateurs ; clients ; employés ; et étudiants.</td>
   </tr>
   <tr>
@@ -98,42 +98,42 @@ Ces personnes sont intégrées en plus petit dans le processus.</td>
   <tr>
     <td>(suite de la liste)
       <ul>
-        <li> l’équipe chargée du projet est plus motivée lorsqu’elle comprend les conséquences positives de leur travail dans la vie des utilisateurs ;</li>
+        <li>l’équipe chargée du projet est plus motivée lorsqu’elle comprend les conséquences positives de son travail dans la vie des utilisateurs ;</li>
       </ul></td>
     <td>Les icônes représentant le processus sont toujours présentes et les personnes sont remplacées par une jauge de motivation.</td>
   </tr>
   <tr>
     <td>(suite de la liste)
       <ul>
-        <li> le développement est plus efficient, et vos produits fonctionnent mieux pour plus de personnes, avec ou sans handicap ;</li>
+        <li>le développement est plus efficient, et vos produits fonctionnent mieux pour plus de personnes, avec ou sans handicap ;</li>
       </ul></td>
     <td>Les icônes représentant le processus sont toujours présentes et la jauge est remplacée par un graphique montrant des résultats en hausse. Le graphique est remplacé par des silhouettes de plusieurs personnes.</td>
   </tr>
   <tr>
     <td>(suite de la liste)
       <ul>
-        <li> et vos produits finaux sont plus inclusifs, touchent un public plus large, augmentent la satisfaction client, et démontrent votre responsabilité sociale.</li>
+        <li>et vos produits finaux sont plus inclusifs, touchent un public plus large, augmentent la satisfaction client, et démontrent votre responsabilité sociale.</li>
       </ul></td>
     <td>Le nombre des personnes croît et les icônes représentant le processus disparaissent. Un classement à cinq étoiles apparaît au-dessus des personnes et les cinq étoiles se remplissent. Les personnes laissent place à une Terre contenant un cœur en son milieu.</td>
   </tr>
   <tr>
-    <td>« Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité » fournit des conseils pour organiser un projet, et un accompagnement tout au long du processus de conception et de développement. </td>
+    <td>« Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité » fournit des conseils pour organiser un projet, et un accompagnement tout au long du processus de conception et de développement.</td>
     <td>Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité. Le cycle représentant le processus de développement, qui inclut les icônes, apparaît.</td>
   </tr>
   <tr>
-    <td>« Impliquer les utilisateurs dans l’évaluation de l’accessibilité Web » fournit une aide plus spécifique sur l’étape d’évaluation du processus. </td>
+    <td>« Impliquer les utilisateurs dans l’évaluation de l’accessibilité Web » fournit une aide plus spécifique sur l’étape d’évaluation du processus.</td>
     <td>Impliquer les utilisateurs dans l’évaluation de l’accessibilité Web. Les icônes du cycle représentant le processus sont mises en avant tour à tour à l’aide d’une loupe.</td>
   </tr>
   <tr>
-    <td>Ensemble, ces ressources vous aident à vous concentrer sur l’accessibilité pour les utilisateurs de votre site Web plutôt sur les seuls pré-requis techniques. </td>
+    <td>Ensemble, ces ressources vous aident à vous concentrer sur l’accessibilité pour les personnes qui utilisent votre site Web plutôt que sur les seuls pré-requis techniques. </td>
     <td>« Impliquer les utilisateurs dans l’évaluation de l’accessibilité Web » et « Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité » fusionnent et se transforment en une personne face à l’ordinateur. Sur l’écran, les éléments accessibles et non-accessibles sont signalés.</td>
   </tr>
   <tr>
-    <td>L’accessibilité Web : essentielle pour certains, utile à tous. </td>
+    <td>L’accessibilité du Web : essentielle pour certains, utile à tous.</td>
     <td>Des icônes apparaissent autour d’un ordinateur : une main ; un œil ; un cerveau ; une oreille ; et une bouche avec des ondes sonores.</td>
   </tr>
   <tr>
-    <td>Pour plus d’informations sur l’implication des utilisateurs, consultez w3.o-r-g/W-A-I/involve-users. </td>
+    <td>Pour plus d’informations sur l’implication des utilisateurs dans l'accessibilité Web, consultez w3.o-r-g/W-A-I/involve-users.</td>
     <td>Impliquer les utilisateurs dans l’accessibilité Web. Logos du W3C et de l’Initiative pour l’accessibilité du Web (WAI)</td>
   </tr>
 </tbody>

--- a/content/index.fr.md
+++ b/content/index.fr.md
@@ -1,10 +1,10 @@
 ---
 # Translation info https://www.w3.org/wiki/WAI/Website/Translate
-title: "Impliquer les utilisateurs dans l'évaluation de l'accessibilité Web"
+title: "Impliquer les utilisateurs dans l’évaluation de l’accessibilité Web"
 permalink: /test-evaluate/involving-users/fr
 ref: /test-evaluate/involving-users/
 lang: fr
-last_updated: 2021-07-12
+last_updated: 2021-06-02
 translators:
 - name: "Rémi Bétin"
 - name: "Sofia Ahmed"
@@ -14,12 +14,12 @@ contributors:
 github:
   repository: w3c/wai-InvolveUsersEval
   path: content/index.fr.md
-description: Introduit des considérations pour les tests d'utilisabilité et autres évaluations avec des personnes handicapées ("utilisateurs en situation de handicap").
+description: Introduit des considérations pour les tests d’utilisabilité et autres évaluations avec des personnes handicapées ("utilisateurs en situation de handicap").
 footer: >
-  <p>Note à propos de l'audiodescription : la vidéo présente sur cette page n'inclut pas l'audiodescription synchronisée car les images n'illustrent que l'audio et ne fournissent pas d'informations supplémentaires. Dans ce cas-ci, l'audiodescription serait plus distrayante qu'utile pour la plupart des utilisateurs, y compris pour les personnes qui ne peuvent pas voir les images. La description des informations contenues dans les images est reprise dans la transcription textuelle avec description des visuels ("transcription descriptive").</p>
-  <p><strong>Date :</strong> Mise à jour : 1<sup>er</sup> juin 2021. Première publication : novembre 2005.</p>
-  <p><strong>Rédactrice :</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. <a href="https://www.w3.org/WAI/eval/ack#users">La page des remerciements</a> liste les contributeurs.</p>
-  <p>Développé par le groupe de travail Éducation et Promotion (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Mis à jour dans le cadre du <a href="http://www.w3.org/WAI/WAI-AGE/"> projet WAI-AGE</a> financé par la Commission européenne au titre du 6e programme-cadre. Vidéo créée avec le soutien du projet <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> financé par la Commission européenne dans le cadre du programme Horizon 2020 (convention de subvention n°822245). <a href="/WAI/test-evaluate/acknowledgements">Remerciements pour la vidéo</a>.</p>
+  <p>Note à propos de l’audiodescription : la vidéo présente sur cette page n’inclut pas l’audiodescription synchronisée car les images n’illustrent que l’audio et ne fournissent pas d’informations supplémentaires. Dans ce cas-ci, l’audiodescription serait plus distrayante qu’utile pour la plupart des utilisateurs, y compris pour les personnes qui ne peuvent pas voir les images. La description des informations contenues dans les images est reprise dans la transcription textuelle avec description des visuels (« transcription descriptive »).</p>
+  <p><strong>Date :</strong> Mise à jour : 1<sup>er</sup> juin 2021. Première publication : novembre 2005.</p>
+  <p><strong>Rédactrice :</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. <a href="https://www.w3.org/WAI/eval/ack#users">La page des remerciements</a> liste les contributeurs.</p>
+  <p>Développé par le groupe de travail Éducation et Promotion (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Mis à jour dans le cadre du <a href="http://www.w3.org/WAI/WAI-AGE/"> projet WAI-AGE</a> financé par la Commission européenne au titre du 6e programme-cadre. Vidéo créée avec le soutien du projet <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> financé par la Commission européenne dans le cadre du programme Horizon 2020 (convention de subvention n° 822245). <a href="/WAI/test-evaluate/acknowledgements">Remerciements pour la vidéo</a>.</p>
 
 ---
 
@@ -27,7 +27,7 @@ footer: >
 {% include box.html type="start" title="Résumé" class="" %}
 {:/}
 
-Cette page introduit des considérations pour les tests d'utilisabilité et autres évaluations avec des personnes handicapées ("utilisateurs en situation de handicap").
+Cette page introduit des considérations pour les tests d’utilisabilité et autres évaluations avec des personnes handicapées (« utilisateurs en situation de handicap »).
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -48,18 +48,18 @@ Cette page introduit des considérations pour les tests d'utilisabilité et autr
 
 {% include excol.html type="start" id="video-intro" %}
 
-## {% include image.html src="video-thumb-involving-users.png" alt="" class="video tiny" %} Vidéo : Impliquer les utilisateurs dans l'accessibilité Web - Vue d'ensemble {#video}
+## {% include image.html src="video-thumb-involving-users.png" alt="" class="video tiny" %} Vidéo : Impliquer les utilisateurs dans l’accessibilité Web – Vue d’ensemble {#video}
 
 {% include excol.html type="middle" %}
 
 {% include video-player.html
-    yt-id="lIA2zTXq_ts"
-    path="/content-images/wai-InvolveUsersEval/"
-    captions="involving-users-cc.vtt|en"
-    subtitles="involving-users-fr.vtt|fr|default"
+yt-id="lIA2zTXq_ts"
+path="/content-images/wai-InvolveUsersEval/"
+captions="involving-users-cc.vtt|en"
+subtitles="involving-users-fr.vtt|fr|default"
 %}
 
-_Cette vidéo est aussi disponible sur un serveur du W3C : [Vidéo : Impliquer les utilisateurs dans l'accessibilité Web - Vue d'ensemble (format du fichier : MP4, taille du fichier : 38 Mo)](http://media.w3.org/wai/evaluation-intros/involving-users.mp4)._
+_Cette vidéo est aussi disponible sur un serveur du W3C : [Vidéo : Impliquer les utilisateurs dans l’accessibilité Web – Vue d’ensemble (format du fichier : MP4, taille du fichier : 38 Mo)](http://media.w3.org/wai/evaluation-intros/involving-users.mp4)._
 
 {% include excol.html type="start" id="video-intro-transcript" %}
 
@@ -76,65 +76,65 @@ Transcription textuelle avec description des visuels
   </thead>
 <tbody>
   <tr>
-    <td>Impliquer les utilisateurs dans l'accessibilité Web.</td>
-    <td>Impliquer les utilisateurs dans l'accessibilité Web.</td>
+    <td>Impliquer les utilisateurs dans l’accessibilité Web. </td>
+    <td>Impliquer les utilisateurs dans l’accessibilité Web.</td>
   </tr>
   <tr>
-    <td>L'accessibilité Web consiste à rendre vos sites et vos applications Web utilisables par les personnes en situation de handicap. Il s'agit de vos consommateurs, vos clients, vos employés, vos étudiants, etc.</td>
-    <td>L'accessibilité. Une personne se trouve face à un ordinateur. À côté de l'ordinateur apparaissent les mots : consommateurs ; clients ; employés ; et étudiants.</td>
+    <td>L’accessibilité Web consiste à rendre vos sites et vos applications Web utilisables par des personnes en situation de handicap. Nous parlons de vos consommateurs, de vos clients, de vos employés, de vos étudiants, etc. </td>
+    <td>L’accessibilité. Une personne se trouve face à un ordinateur. À côté de l’ordinateur apparaissent les mots : consommateurs ; clients ; employés ; et étudiants.</td>
   </tr>
   <tr>
-    <td>Malheureusement, bon nombre de personnes considèrent l'accessibilité uniquement comme une liste de choses à vérifier. En faisant cela, elles risquent de passer à côté de la raison d'être de l'accessibilité : l'expérience utilisateur. </td>
-    <td>Une liste remplace la personne. Le site Web sur l'écran s'écroule. 4 personnes remplacent l'ordinateur et la liste.</td>
+    <td>Malheureusement, bon nombre de personnes considèrent l’accessibilité uniquement comme une liste de choses à vérifier. En faisant cela, elles risquent de passer à côté de la raison d’être de l’accessibilité : l’expérience utilisateur. </td>
+    <td>Une liste remplace la personne. Le site Web sur l’écran s’écroule. 4 personnes remplacent l’ordinateur et la liste.</td>
   </tr>
   <tr>
-    <td>Impliquer des personnes en situation de handicap tout au long des processus de conception et de développement peut s'avérer plus efficace et produire de meilleurs résultats :
+    <td>Impliquer des personnes en situation de handicap tout au long des processus de conception et de développement peut s’avérer plus efficace et produire de meilleurs résultats :
       <ul>
-        <li> les designers et les développeurs apprennent comment les personnes en situation de handicap utilisent le Web, et comprennent les technologies d'assistance et les stratégies d'adaptation qu'elles utilisent ;</li>
+        <li> les designers et les développeurs apprennent comment les personnes en situation de handicap utilisent le Web, et comprennent les technologies d’assistance et les stratégies d’adaptation qu’elles utilisent ;</li>
       </ul></td>
-    <td>Le groupe de personnes est entouré par des icônes au sein d'un cycle représentant le processus de développement : une icône crayon ; une icône de codage ; une icône pinceau ; et une icône loupe.
+    <td>Le groupe de personnes est entouré par des icônes au sein d’un cycle représentant le processus de développement : une icône crayon ; une icône de codage ; une icône pinceau ; et une icône loupe.
 Ces personnes sont intégrées en plus petit dans le processus.</td>
   </tr>
   <tr>
     <td>(suite de la liste)
       <ul>
-        <li>l'équipe chargée du projet est plus motivée lorsqu'elle comprend les conséquences positives de son travail dans la vie des utilisateurs ;</li>
+        <li> l’équipe chargée du projet est plus motivée lorsqu’elle comprend les conséquences positives de leur travail dans la vie des utilisateurs ;</li>
       </ul></td>
     <td>Les icônes représentant le processus sont toujours présentes et les personnes sont remplacées par une jauge de motivation.</td>
   </tr>
   <tr>
     <td>(suite de la liste)
       <ul>
-        <li>le développement est plus efficient, et vos produits fonctionnent mieux pour plus de personnes, avec ou sans handicap ;</li>
+        <li> le développement est plus efficient, et vos produits fonctionnent mieux pour plus de personnes, avec ou sans handicap ;</li>
       </ul></td>
     <td>Les icônes représentant le processus sont toujours présentes et la jauge est remplacée par un graphique montrant des résultats en hausse. Le graphique est remplacé par des silhouettes de plusieurs personnes.</td>
   </tr>
   <tr>
     <td>(suite de la liste)
       <ul>
-        <li>et vos produits finaux sont plus inclusifs, touchent un public plus large, augmentent la satisfaction client, et démontrent votre responsabilité sociale.</li>
+        <li> et vos produits finaux sont plus inclusifs, touchent un public plus large, augmentent la satisfaction client, et démontrent votre responsabilité sociale.</li>
       </ul></td>
     <td>Le nombre des personnes croît et les icônes représentant le processus disparaissent. Un classement à cinq étoiles apparaît au-dessus des personnes et les cinq étoiles se remplissent. Les personnes laissent place à une Terre contenant un cœur en son milieu.</td>
   </tr>
   <tr>
-    <td>"Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l'accessibilité" fournit des conseils pour organiser un projet, et un accompagnement tout au long du processus de conception et de développement.</td>
-    <td>Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l'accessibilité. Le cycle représentant le processus de développement, qui inclut les icônes, apparaît.</td>
+    <td>« Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité » fournit des conseils pour organiser un projet, et un accompagnement tout au long du processus de conception et de développement. </td>
+    <td>Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité. Le cycle représentant le processus de développement, qui inclut les icônes, apparaît.</td>
   </tr>
   <tr>
-    <td>"Impliquer les utilisateurs dans l'évaluation de l'accessibilité Web" fournit une aide plus spécifique sur l'étape d'évaluation du processus.</td>
-    <td>Impliquer les utilisateurs dans l'évaluation de l'accessibilité Web. Les icônes du cycle représentant le processus sont mises en avant tour à tour à l'aide d'une loupe.</td>
+    <td>« Impliquer les utilisateurs dans l’évaluation de l’accessibilité Web » fournit une aide plus spécifique sur l’étape d’évaluation du processus. </td>
+    <td>Impliquer les utilisateurs dans l’évaluation de l’accessibilité Web. Les icônes du cycle représentant le processus sont mises en avant tour à tour à l’aide d’une loupe.</td>
   </tr>
   <tr>
-    <td>Ensemble, ces ressources vous aident à vous concentrer sur l'accessibilité pour les personnes qui utilisent votre site Web plutôt que sur les seuls pré-requis techniques. </td>
-    <td>"Impliquer les utilisateurs dans l'évaluation de l'accessibilité Web" et "Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l'accessibilité" fusionnent et se transforment en une personne face à l'ordinateur. Sur l'écran, les éléments accessibles et non-accessibles sont signalés.</td>
+    <td>Ensemble, ces ressources vous aident à vous concentrer sur l’accessibilité pour les utilisateurs de votre site Web plutôt sur les seuls pré-requis techniques. </td>
+    <td>« Impliquer les utilisateurs dans l’évaluation de l’accessibilité Web » et « Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité » fusionnent et se transforment en une personne face à l’ordinateur. Sur l’écran, les éléments accessibles et non-accessibles sont signalés.</td>
   </tr>
   <tr>
-    <td>L'accessibilité du Web : essentielle pour certains, utile à tous.</td>
-    <td>Des icônes apparaissent autour d'un ordinateur : une main ; un œil ; un cerveau ; une oreille ; et une bouche avec des ondes sonores.</td>
+    <td>L’accessibilité Web : essentielle pour certains, utile à tous. </td>
+    <td>Des icônes apparaissent autour d’un ordinateur : une main ; un œil ; un cerveau ; une oreille ; et une bouche avec des ondes sonores.</td>
   </tr>
   <tr>
-    <td>Pour plus d'informations sur l'implication des utilisateurs dans l'accessibilité Web, consultez w3.o-r-g/W-A-I/involve-users.</td>
-    <td>Impliquer les utilisateurs dans l'accessibilité Web. Logos du W3C et de l'Initiative pour l'accessibilité du Web (WAI)</td>
+    <td>Pour plus d’informations sur l’implication des utilisateurs, consultez w3.o-r-g/W-A-I/involve-users. </td>
+    <td>Impliquer les utilisateurs dans l’accessibilité Web. Logos du W3C et de l’Initiative pour l’accessibilité du Web (WAI)</td>
   </tr>
 </tbody>
 </table>
@@ -146,97 +146,97 @@ Ces personnes sont intégrées en plus petit dans le processus.</td>
 
 ## Introduction {#intro}
 
-L'évaluation de l'accessibilité Web met souvent l'accent sur la [conformité aux standards d'accessibilité](/test-evaluate/conformance/) tels que les [WCAG](/standards-guidelines/wcag/). Bien que la conformité ait son importance, [évaluer avec de vraies personnes a de nombreux avantages](/planning/involving-users/#why). Par exemple, pour apprendre comment votre site ou votre outil Web fonctionne réellement pour les utilisateurs, et pour mieux comprendre les problèmes d'accessibilité. Évaluer avec des personnes en situation de handicap et des personnes âgées permet d'identifier les problèmes d'utilisabilité qui ne peuvent pas être détectés uniquement avec une évaluation de conformité.
+L’évaluation de l’accessibilité Web met souvent l’accent sur la [conformité aux standards d’accessibilité](/test-evaluate/conformance/) tels que les [WCAG](/standards-guidelines/wcag/). Bien que la conformité ait son importance, [évaluer avec de vraies personnes a de nombreux avantages](/planning/involving-users/#why). Par exemple, pour apprendre comment votre site ou votre outil Web fonctionne réellement pour les utilisateurs, et pour mieux comprendre les problèmes d’accessibilité. Évaluer avec des personnes en situation de handicap et des personnes âgées permet d’identifier les problèmes d’utilisabilité qui ne peuvent pas être détectés uniquement avec une évaluation de conformité.
 
-Cette page fait partie d'un ensemble de pages intitulé [Évaluer l'accessibilité web](/test-evaluate/) qui offre un aperçu des différents aspects de l'évaluation de l'accessibilité Web. Il s'agit de la seconde page d'un ensemble de deux pages traitant de l'inclusion des utilisateurs dans les projets Web.
+Cette page fait partie d’un ensemble de pages intitulé [Évaluer l’accessibilité web](/test-evaluate/) qui offre un aperçu des différents aspects de l’évaluation de l’accessibilité Web. Il s’agit de la seconde page d’un ensemble de deux pages traitant de l’inclusion des utilisateurs dans les projets Web.
 
-**Veuillez lire [[Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l'accessibilité]](/planning/involving-users/), qui aborde des questions plus vastes sur l'inclusion des utilisateurs *tôt* dans la conception d'un site Web, le développement d'outils, de standards, et d'autres projets Web.**
+**Veuillez lire [[Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité]](/planning/involving-users/), qui aborde des questions plus vastes sur l’inclusion des utilisateurs *tôt* dans la conception d’un site Web, le développement d’outils, de standards, et d’autres projets Web.**
 
 ## Premières vérifications {#prelim}
 
-Une des premières étapes pour évaluer l'accessibilité Web consiste à repérer les problèmes d'accessibilité évidents d'un site Web. À titre d'exemple, vous trouverez certaines vérifications sur [[Vérifications simples – Faire un premier bilan de l'accessibilité Web]](/test-evaluate/preliminary/).
+Une des premières étapes pour évaluer l’accessibilité Web consiste à repérer les problèmes d’accessibilité évidents d’un site Web. À titre d’exemple, vous trouverez certaines vérifications sur [[Vérifications simples – Faire un premier bilan de l’accessibilité Web]](/test-evaluate/preliminary/).
 
-Même les développeurs Web possédant peu de connaissances en accessibilité sont capables de repérer des problèmes d'accessibilité lors d'une première vérification. Un expert en accessibilité qui a une expérience directe de la manière dont les personnes en situation de handicap interagissent avec le Web peut, quant à lui :
+Même les développeurs Web possédant peu de connaissances en accessibilité sont capables de repérer des problèmes d’accessibilité lors d’une première vérification. Un expert en accessibilité qui a une expérience directe de la manière dont les personnes en situation de handicap interagissent avec le Web peut, quant à lui :
 
--   évaluer les problèmes d'accessibilité pour un large éventail d'utilisateurs, qui n'auraient pas forcément été détectés par des utilisateurs individuels ;
--   aider à régler tout obstacle identifié avant d'inclure les utilisateurs ;
+-   évaluer les problèmes d’accessibilité pour un large éventail d’utilisateurs, qui n’auraient pas forcément été détectés par des utilisateurs individuels ;
+-   aider à régler tout obstacle identifié avant d’inclure les utilisateurs ;
 -   axer le test utilisateur sur les parties qui pourraient poser problème
 
-**La première vérification permet d'identifier les obstacles significatifs à l'accessibilité qu'il faudra régler avant l'évaluation impliquant des utilisateurs. Elle aide aussi à identifier sur quoi se concentrer lors des tests utilisateurs.**
+**La première vérification permet d’identifier les obstacles significatifs à l’accessibilité qu’il faudra régler avant l’évaluation impliquant des utilisateurs. Elle aide aussi à identifier sur quoi se concentrer lors des tests utilisateurs.**
 
 ## Types de tests utilisateurs {#range}
 
-Les utilisateurs en situation de handicap et les utilisateurs âgés peuvent être impliqués dans une grande variété d'activités d'évaluation, des consultations rapides aux tests utilisateurs à grande échelle. **Il existe plusieurs options entre ces deux extrêmes** :
+Les utilisateurs en situation de handicap et les utilisateurs âgés peuvent être impliqués dans une grande variété d’activités d’évaluation, des consultations rapides aux tests utilisateurs à grande échelle. **Il existe plusieurs options entre ces deux extrêmes** :
 
--   **Les évaluations informelles** de problèmes spécifiques d'accessibilité peuvent s'avérer très simples. Par exemple, en demandant à quelqu'un qui utilise un lecteur d'écran ou quelqu'un avec un handicap différent de trouver des données dans une première ébauche de tableau de données. Il suffit ensuite d'observer leur interaction et d'échanger sur les différents problèmes rencontrés.
--   **Le test d'utilisabilité formel** d'un site Web suit des protocoles préétablis pour rassembler des données quantitatives et qualitatives provenant d'utilisateurs représentatifs qui réalisent des tâches spécifiques. [Les tests utilisateurs formels peuvent être optimisés](#ut-access) pour mettre en exergue les problèmes d'accessibilité.
+-   **Les évaluations informelles** de problèmes spécifiques d’accessibilité peuvent s’avérer très simples. Par exemple, en demandant à quelqu’un qui utilise un lecteur d’écran ou quelqu’un avec un handicap différent de trouver des données dans une première ébauche de tableau de données. Il suffit ensuite d’observer leur interaction et d’échanger sur les différents problèmes rencontrés.
+-   **Le test d’utilisabilité formel** d’un site Web suit des protocoles préétablis pour rassembler des données quantitatives et qualitatives provenant d’utilisateurs représentatifs qui réalisent des tâches spécifiques. [Les tests utilisateurs formels peuvent être optimisés](#ut-access) pour mettre en exergue les problèmes d’accessibilité.
 
-Le type d'évaluation à pratiquer dépend de facteurs tel que le niveau d'avancement de votre projet ; par exemple, si vous en êtes à la recherche initiale d'idées de conception, au test de zones spécifiques de vos prototypes, ou à la vérification finale de vos créations.
+Le type d’évaluation à pratiquer dépend de facteurs tel que le niveau d’avancement de votre projet ; par exemple, si vous en êtes à la recherche initiale d’idées de conception, au test de zones spécifiques de vos prototypes, ou à la vérification finale de vos créations.
 
-**Mener des évaluations informelles tout au long du développement est plus efficace qu'effectuer un test d'utilisabilité formel en fin de projet.**
+**Mener des évaluations informelles tout au long du développement est plus efficace qu’effectuer un test d’utilisabilité formel en fin de projet.**
 
 ## Les fondamentaux {#basics}
 
-Dans la plupart des cas, inclure les utilisateurs lors de l'évaluation suppose :
+Dans la plupart des cas, inclure les utilisateurs lors de l’évaluation suppose :
 
--   d'inclure quelques utilisateurs en situation de handicap - et selon votre public cible, des utilisateurs âgés
--   de les inclure tout au long du développement pour effectuer des tâches types sur vos prototypes, afin de vous permettre d'identifier comment améliorer différents aspects de la conception et du code
--   d'échanger avec eux sur les problèmes d'accessibilité
+-   d’inclure quelques utilisateurs en situation de handicap - et selon votre public cible, des utilisateurs âgés
+-   de les inclure tout au long du développement pour effectuer des tâches types sur vos prototypes, afin de vous permettre d’identifier comment améliorer différents aspects de la conception et du code
+-   d’échanger avec eux sur les problèmes d’accessibilité
 
-**Consultez [[Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l'accessibilité]](/planning/involving-users/)** pour en savoir plus sur [le recrutement d'une palette d'utilisateurs](/WAI/users/involving#diverse) et sur [l'expérience des utilisateurs interagissant avec le Web](/WAI/users/involving#experience).
+**Consultez [[Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité]](/planning/involving-users/)** pour en savoir plus sur [le recrutement d’une palette d’utilisateurs](/WAI/users/involving#diverse) et sur [l’expérience des utilisateurs interagissant avec le Web](/WAI/users/involving#experience).
 
-Comme pour toute évaluation avec des utilisateurs, inclure des utilisateurs de niveau basique, intermédiaire ou avancé dépendra de vos utilisateurs cibles. Par exemple, si vous développez une application Web pour des comptables au sein d'une entreprise, vous opterez certainement pour des utilisateurs ayant un usage avancé des technologies d'assistance. En revanche, pour un site Web destiné aux demandes de prestation d'invalidité, vous travaillerez plutôt avec des utilisateurs novices dans l'usage des technologies d'assistance.
+Comme pour toute évaluation avec des utilisateurs, inclure des utilisateurs de niveau basique, intermédiaire ou avancé dépendra de vos utilisateurs cibles. Par exemple, si vous développez une application Web pour des comptables au sein d’une entreprise, vous opterez certainement pour des utilisateurs ayant un usage avancé des technologies d’assistance. En revanche, pour un site Web destiné aux demandes de prestation d’invalidité, vous travaillerez plutôt avec des utilisateurs novices dans l’usage des technologies d’assistance.
 
-<mark id="caution"><strong>Attention :</strong> Considérez avec précaution chaque contribution. <strong>Évitez de supposer que la contribution d'une personne présentant une certaine forme de handicap s'applique à toutes les personnes en situation de handicap. </strong></mark>
+<mark id="caution"><strong>Attention :</strong> Considérez avec précaution chaque contribution. <strong>Évitez de supposer que la contribution d’une personne présentant une certaine forme de handicap s’applique à toutes les personnes en situation de handicap. </strong></mark>
 
-Une personne en situation de handicap ne sait pas forcément comment d'autres personnes présentant le même type de handicap interagissent avec le Web. Elle pourrait ne pas en savoir assez sur les autres handicaps pour fournir une aide valable pour d'autres questions d'accessibilité. Il est préférable d'obtenir des contributions de plusieurs types d'utilisateurs.
+Une personne en situation de handicap ne sait pas forcément comment d’autres personnes présentant le même type de handicap interagissent avec le Web. Elle pourrait ne pas en savoir assez sur les autres handicaps pour fournir une aide valable pour d’autres questions d’accessibilité. Il est préférable d’obtenir des contributions de plusieurs types d’utilisateurs.
 
-À noter : en plus de détecter des problèmes d'accessibilité, l'évaluation menée avec des utilisateurs en situation de handicap révèle habituellement des problèmes généraux d'utilisabilité qui touchent tous les utilisateurs, y compris ceux qui ne se trouvent *pas* en situation de handicap.
+À noter : en plus de détecter des problèmes d’accessibilité, l’évaluation menée avec des utilisateurs en situation de handicap révèle habituellement des problèmes généraux d’utilisabilité qui touchent tous les utilisateurs, y compris ceux qui ne se trouvent *pas* en situation de handicap.
 
-## Analyser les problèmes d'accessibilité {#analyz}
+## Analyser les problèmes d’accessibilité {#analyz}
 
-L'accessibilité Web nécessite que des [composantes multiples du développement Web et de l'interaction utilisateur](/fundamentals/components/) s'articulent convenablement, notamment les navigateurs Web, les technologies d'assistance, et le contenu Web.
+L’accessibilité Web nécessite que des [composantes multiples du développement Web et de l’interaction utilisateur](/fundamentals/components/) s’articulent convenablement, notamment les navigateurs Web, les technologies d’assistance, et le contenu Web.
 
-Les problèmes d'accessibilité peuvent être causés par une ou plusieurs composantes. Par exemple, si un utilisateur qui ne peut pas utiliser une souris éprouve des difficultés d'accès avec le clavier, il peut y avoir plusieurs explications :
+Les problèmes d’accessibilité peuvent être causés par une ou plusieurs composantes. Par exemple, si un utilisateur qui ne peut pas utiliser une souris éprouve des difficultés d’accès avec le clavier, il peut y avoir plusieurs explications :
 
--   le développeur n'a pas balisé/codé correctement la page Web, ou
+-   le développeur n’a pas balisé/codé correctement la page Web, ou
 -   le navigateur ou le lecteur multimédia ne traite pas correctement le balisage, ou
--   la technologie d'assistance de l'utilisateur ne traite pas correctement le balisage, ou
--   l'utilisateur ne sait pas comment utiliser le navigateur, le lecteur multimédia ou les fonctionnalités accessibles au clavier des technologies d'assistance, ou
--   la page est mal conçue et il s'agit d'un problème général d'utilisabilité touchant tous les utilisateurs, y compris ceux qui ne se trouvent *pas* en situation de handicap.
+-   la technologie d’assistance de l’utilisateur ne traite pas correctement le balisage, ou
+-   l’utilisateur ne sait pas comment utiliser le navigateur, le lecteur multimédia ou les fonctionnalités accessibles au clavier des technologies d’assistance, ou
+-   la page est mal conçue et il s’agit d’un problème général d’utilisabilité touchant tous les utilisateurs, y compris ceux qui ne se trouvent *pas* en situation de handicap.
 
-## Associez l'implication des utilisateurs et les standards {#stdstoo}
+## Associez l’implication des utilisateurs et les standards {#stdstoo}
 
-Inclure les utilisateurs en situation de handicap dans l'évaluation présente de nombreux avantages. Ceci dit, cela ne suffit pas à déterminer si un site Web est accessible. Associez l'implication des utilisateurs et l'[évaluation de la conformité aux WCAG](/test-evaluate/conformance/) afin de garantir que le site est accessible aux utilisateurs pour différents types de handicaps et de situations.
+Inclure les utilisateurs en situation de handicap dans l’évaluation présente de nombreux avantages. Ceci dit, cela ne suffit pas à déterminer si un site Web est accessible. Associez l’implication des utilisateurs et l’[évaluation de la conformité aux WCAG](/test-evaluate/conformance/) afin de garantir que le site est accessible aux utilisateurs pour différents types de handicaps et de situations.
 
 ## Tirer des conclusions et créer un rapport {#drawing}
 
-Soyez vigilants si vous tirez des conclusions à partir d'évaluations ou d'études limitées. Les résultats obtenus avec deux personnes en situation de handicap ne peuvent être généralisés et appliqués à toutes les personnes dans la même situation de handicap ou présentant d'autres handicaps. Retrouvez plus d'informations dans la section [Attention](#caution) ci-dessus.
+Soyez vigilants si vous tirez des conclusions à partir d’évaluations ou d’études limitées. Les résultats obtenus avec deux personnes en situation de handicap ne peuvent être généralisés et appliqués à toutes les personnes dans la même situation de handicap ou présentant d’autres handicaps. Retrouvez plus d’informations dans la section [Attention](#caution) ci-dessus.
 
-Incluez dans votre rapport le périmètre de votre étude et les paramètres de l'évaluation, tels que les méthodes de test et les caractéristiques des utilisateurs. Par exemple, si une étude a inclus uniquement des personnes aveugles, le rapport devra préciser que celle-ci n'a pas évalué la conformité aux standards d'accessibilité et qu'elle ne s'applique pas à toutes les personnes handicapées. Bien que les études de petite envergure peuvent souvent fournir des informations utiles, elles ne sont pas assez solides pour avoir une importance statistique.
+Incluez dans votre rapport le périmètre de votre étude et les paramètres de l’évaluation, tels que les méthodes de test et les caractéristiques des utilisateurs. Par exemple, si une étude a inclus uniquement des personnes aveugles, le rapport devra préciser que celle-ci n’a pas évalué la conformité aux standards d’accessibilité et qu’elle ne s’applique pas à toutes les personnes handicapées. Bien que les études de petite envergure peuvent souvent fournir des informations utiles, elles ne sont pas assez solides pour avoir une importance statistique.
 
-## Note à l'attention des ergonomes {#ut-access}
+## Note à l’attention des ergonomes {#ut-access}
 
-Lors de la recherche d'obstacles spécifiques à l'accessibilité, le protocole est généralement différent d'un test d'utilisabilité général. Par exemple :
+Lors de la recherche d’obstacles spécifiques à l’accessibilité, le protocole est généralement différent d’un test d’utilisabilité général. Par exemple :
 
--  vous utiliseriez certainement une technique de "réflexion à haute-voix" et une forte interaction avec l'animateur
--  la collecte de données s'attacherait surtout à comprendre les erreurs liées aux obstacles à l'accessibilité, plutôt que sur le temps passé à réaliser une tâche ou sur la satisfaction utilisateur
--  les tâches se concentreraient sur des zones spécifiques qui pourraient potentiellement poser des problèmes d'accessibilité, plutôt que sur l'utilisation générale du site
+-  vous utiliseriez certainement une technique de « réflexion à haute-voix » et une forte interaction avec l’animateur
+-  la collecte de données s’attacherait surtout à comprendre les erreurs liées aux obstacles à l’accessibilité, plutôt que sur le temps passé à réaliser une tâche ou sur la satisfaction utilisateur
+-  les tâches se concentreraient sur des zones spécifiques qui pourraient potentiellement poser des problèmes d’accessibilité, plutôt que sur l’utilisation générale du site
 
-Notez qu'il est également important d'évaluer d'autres facteurs pour les utilisateurs en situation de handicap. Ces facteurs comprennent : l'utilisabilité générale, la satisfaction utilisateur, et d'autres critères semblables.
+Notez qu’il est également important d’évaluer d’autres facteurs pour les utilisateurs en situation de handicap. Ces facteurs comprennent : l’utilisabilité générale, la satisfaction utilisateur, et d’autres critères semblables.
 
-La section "Plus d'informations" ci-dessous inclut une aide supplémentaire à l'attention des ergonomes.
+La section « Plus d’informations » ci-dessous inclut une aide supplémentaire à l’attention des ergonomes.
 
-## Plus d'informations et de conseils {#fmi}
+## Plus d’informations et de conseils {#fmi}
 
-Ce document aborde brièvement quelques points d'un sujet très complexe. De nombreuses ressources traitant des autres aspects liés à l'implication des utilisateurs dans l'évaluation sont disponibles sur le Web.
+Ce document aborde brièvement quelques points d’un sujet très complexe. De nombreuses ressources traitant des autres aspects liés à l’implication des utilisateurs dans l’évaluation sont disponibles sur le Web.
 
--  **[[Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l'accessibilité]](/planning/involving-users/) constitue un préalable essentiel à ce document**. Cette page traite de questions plus vastes sur l'implication des utilisateurs tôt dans la conception d'un site Web, le développement d'outils, de standards, et d'autres projets Web.
--   [<cite>Just Ask: Integrating Accessibility Throughout Design</cite> (en anglais)](http://www.uiaccess.com/accessucd/overview.html) fournit de l'aide sur l'intégration de l'accessibilité tout au long de la conception de sites Web et d'autres produits. Le chapitre sur les [tests utilisateurs pour évaluer l'accessibilité](http://www.uiaccess.com/accessucd/ut.html) détaille les différentes phases suivantes :
-    -   Organiser un test utilisateur pour évaluer l'accessibilité – [déterminer les caractéristiques des participants](http://www.uiaccess.com/accessucd/ut_plan.html#characteristics), [recruter des participants](http://www.uiaccess.com/accessucd/ut_plan.html#recruiting), fournir une compensation
-    -   Préparer le test d'utilisabilité pour évaluer l'accessibilité – préparer des supports de test, garantir l'accessibilité des installations, mettre en place et tester les technologies d'assistance, mener un test pilote, utiliser des [techniques d'observation](http://www.uiaccess.com/accessucd/screening.html)
-    -   Mener un test d'utilisabilité pour évaluer l'accessibilité – [interagir avec des personnes handicapées](http://www.uiaccess.com/accessucd/ut_conduct.html#interacting), préparer la pièce où aura lieu le test
-    -   [Créer un rapport à partir du test d'utilisabilité pour évaluer l'accessibilité](http://www.uiaccess.com/accessucd/ut_report.html) – distinguer les problèmes d'accessibilité des problèmes d'utilisabilité, tirer des conclusions, donner des informations sur les personnes handicapées
--   [Livre blanc : mener des tests utilisateurs avec des personnes en situation de handicap (en anglais)](https://web.archive.org/web/20160603030517/http://www-03.ibm.com/able/resources/userevaluations.html)
--   De nombreux livres, articles, supports de conférences, et d'autres ressources traitent des différentes méthodes pour évaluer l'utilisabilité. Ces ressources comprennent divers types de tests utilisateurs, des conceptions de tests, des protocoles de développement de tests, dont des questionnaires, des tâches, la collecte de données ; la réalisation de tests pilotes ; et le nombre de participants à inclure dans un test d'utilisabilité. Par exemple : [<cite>Usability Testing Demystified</cite> (en anglais)](http://www.alistapart.com/articles/usability-testing-demystified/), [les exemples de plans et de formulaires de test tirés de <cite>The Handbook of Usability Testing</cite> (en anglais)"](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0470185481,descCd-DOWNLOAD.html), et [<cite>Rocket Surgery Made Easy: The Do-It-Yourself Guide to Finding and Fixing Usability Problems</cite> (en anglais)](http://www.sensible.com/rocketsurgery/index.html) avec un exemple de test d'utilisabilité, des scripts et des formulaires en ligne.
--   Il existe des organisations partout dans le monde spécialisées dans l'accompagnement pour recruter des personnes en situation de handicap et mener des évaluations avec des utilisateurs en situation de handicap.
+-  **[[Impliquer les utilisateurs dans les projets Web pour améliorer et faciliter l’accessibilité]](/planning/involving-users/) constitue un préalable essentiel à ce document**. Cette page traite de questions plus vastes sur l’implication des utilisateurs tôt dans la conception d’un site Web, le développement d’outils, de standards, et d’autres projets Web.
+-   [<cite lang="en">Just Ask: Integrating Accessibility Throughout Design</cite>](http://www.uiaccess.com/accessucd/overview.html) (en anglais) fournit de l’aide sur l’intégration de l’accessibilité tout au long de la conception de sites Web et d’autres produits. Le chapitre sur les [tests utilisateurs pour évaluer l’accessibilité](http://www.uiaccess.com/accessucd/ut.html) détaille les différentes phases suivantes :
+    -   Organiser un test utilisateur pour évaluer l’accessibilité – [déterminer les caractéristiques des participants](http://www.uiaccess.com/accessucd/ut_plan.html#characteristics), [recruter des participants](http://www.uiaccess.com/accessucd/ut_plan.html#recruiting), fournir une compensation
+    -   Préparer le test d’utilisabilité pour évaluer l’accessibilité – préparer des supports de test, garantir l’accessibilité des installations, mettre en place et tester les technologies d’assistance, mener un test pilote, utiliser des [techniques d’observation](http://www.uiaccess.com/accessucd/screening.html)
+    -   Mener un test d’utilisabilité pour évaluer l’accessibilité – [interagir avec des personnes handicapées](http://www.uiaccess.com/accessucd/ut_conduct.html#interacting), préparer la pièce où aura lieu le test
+    -   [Créer un rapport à partir du test d’utilisabilité pour évaluer l’accessibilité](http://www.uiaccess.com/accessucd/ut_report.html) – distinguer les problèmes d’accessibilité des problèmes d’utilisabilité, tirer des conclusions, donner des informations sur les personnes handicapées
+-   [Livre blanc : mener des tests utilisateurs avec des personnes en situation de handicap (en anglais)](https://web.archive.org/web/20160603030517/http://www-03.ibm.com/able/resources/userevaluations.html)
+-   De nombreux livres, articles, supports de conférences, et d’autres ressources traitent des différentes méthodes pour évaluer l’utilisabilité. Ces ressources comprennent divers types de tests utilisateurs, des conceptions de tests, des protocoles de développement de tests, dont des questionnaires, des tâches, la collecte de données ; la réalisation de tests pilotes ; et le nombre de participants à inclure dans un test d’utilisabilité. Par exemple : [<cite lang="en">Usability Testing Demystified</cite>](http://www.alistapart.com/articles/usability-testing-demystified/) (en anglais), [les exemples de plans et de formulaires de test tirés de <cite lang="en">The Handbook of Usability Testing</cite>"](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0470185481,descCd-DOWNLOAD.html) (en anglais), et [<cite lang="en">Rocket Surgery Made Easy: The Do-It-Yourself Guide to Finding and Fixing Usability Problems</cite>](http://www.sensible.com/rocketsurgery/index.html) (en anglais) avec un exemple de test d’utilisabilité, des scripts et des formulaires en ligne.
+-   Il existe des organisations partout dans le monde spécialisées dans l’accompagnement pour recruter des personnes en situation de handicap et mener des évaluations avec des utilisateurs en situation de handicap.

--- a/content/index.fr.md
+++ b/content/index.fr.md
@@ -80,7 +80,7 @@ Transcription textuelle avec description des visuels
     <td>Impliquer les utilisateurs dans l’accessibilité Web.</td>
   </tr>
   <tr>
-    <td>L’accessibilité Web consiste à rendre vos sites et vos applications Web utilisables par les personnes en situation de handicap. Il s’agit de vos consommateurs, de vos clients, de vos employés, de vos étudiants, etc. </td>
+    <td>L’accessibilité Web consiste à rendre vos sites et vos applications Web utilisables par les personnes en situation de handicap. Il s’agit de vos consommateurs, vos clients, vos employés, vos étudiants, etc.</td>
     <td>L’accessibilité. Une personne se trouve face à un ordinateur. À côté de l’ordinateur apparaissent les mots : consommateurs ; clients ; employés ; et étudiants.</td>
   </tr>
   <tr>


### PR DESCRIPTION
Integrates https://github.com/w3c/wai-InvolveUsersEval/pull/26 from @3l3gant-cod3s (and fix conflicts)

- systematic use of required nbsp (no-break space): as required by French typography, inserted nbsp before or after double punctation symbols («»:;!? etc.)
- add language to cite tags

Resolves https://github.com/w3c/wai-translations/issues/78